### PR TITLE
Intermix::Vacuum - fix thresholds to actually respect percent values

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+## 0.0.3
+* [Intermix::Vacuum - fix thresholds to actually respect percent values](https://github.com/tophatter/intermix-api-ruby/pull/9)
+
 ## 0.0.2
 * [Downgrade httparty from 0.17.0 to 0.14.0](https://github.com/tophatter/intermix-api-ruby/pull/6)
 

--- a/intermix-client.gemspec
+++ b/intermix-client.gemspec
@@ -3,7 +3,7 @@
 # gem push intermix-client-{VERSION}.gem
 Gem::Specification.new do |spec|
   spec.name          = 'intermix-client'
-  spec.version       = '0.0.2'
+  spec.version       = '0.0.3'
   spec.authors       = ['Joe Manley']
   spec.email         = ['joemanley201@gmail.com']
 

--- a/spec/support/shared_contexts/stubbed_client.rb
+++ b/spec/support/shared_contexts/stubbed_client.rb
@@ -14,8 +14,8 @@ RSpec.shared_context 'stubbed_client' do
       schema_name: 'public',
       table_id: 1,
       table_name: 'events',
-      stats_pct_off: 0.12,
-      size_pct_unsorted: 0.13,
+      stats_pct_off: 12,
+      size_pct_unsorted: 13,
       row_count: 123_456,
       sort_key: 'id'
     }

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Intermix::Table do
         expect(subject.schema_name).to eq('public')
         expect(subject.table_id).to eq(1)
         expect(subject.table_name).to eq('events')
-        expect(subject.stats_pct_off).to eq(0.12)
-        expect(subject.size_pct_unsorted).to eq(0.13)
+        expect(subject.stats_pct_off).to eq(12)
+        expect(subject.size_pct_unsorted).to eq(13)
         expect(subject.row_count).to eq(123_456)
         expect(subject.sort_key).to eq('id')
       end

--- a/spec/vacuum_spec.rb
+++ b/spec/vacuum_spec.rb
@@ -59,8 +59,9 @@ RSpec.describe Intermix::Vacuum do
           expect(subject.sort).to be_falsey
           expect(subject.analyze).to be_truthy
 
-          expect(subject.stats_off_threshold).to eq(0.10)
-          expect(subject.stats_off_threshold).to eq(0.10)
+          expect(subject.stats_off_threshold_pct).to eq(10)
+          expect(subject.unsorted_threshold_pct).to eq(10)
+          expect(subject.vacuum_threshold_pct).to eq(95)
 
           expect(subject.admin_user).to eq('')
           expect(subject.host).to eq('')
@@ -71,19 +72,19 @@ RSpec.describe Intermix::Vacuum do
   end
 
   describe '#generate_script', :stubbed_client do
-    let(:stats_off_threshold) { 0.21 }
-    let(:unsorted_threshold) { 0.22 }
+    let(:stats_off_threshold_pct) { 21 }
+    let(:unsorted_threshold_pct) { 22 }
     let(:threshold_met) do
       [
-        stubbed_table.merge(table_name: 'table1', stats_pct_off: 0.45, size_pct_unsorted: 0.41), # included
-        stubbed_table.merge(table_name: 'table2', stats_pct_off: 0.56, size_pct_unsorted: 0.78)  # included
+        stubbed_table.merge(table_name: 'table1', stats_pct_off: 45, size_pct_unsorted: 41), # included
+        stubbed_table.merge(table_name: 'table2', stats_pct_off: 56, size_pct_unsorted: 78)  # included
       ]
     end
     let(:threshold_unmet) do
       [
-        stubbed_table.merge(table_name: 'table3', stats_pct_off: 0.45, size_pct_unsorted: nil),  # excluded
-        stubbed_table.merge(table_name: 'table4', stats_pct_off: 0.45, size_pct_unsorted: 0.20), # excluded
-        stubbed_table.merge(table_name: 'table5', stats_pct_off: 0.20, size_pct_unsorted: 0.41)  # excluded
+        stubbed_table.merge(table_name: 'table3', stats_pct_off: 45, size_pct_unsorted: nil),  # excluded
+        stubbed_table.merge(table_name: 'table4', stats_pct_off: 45, size_pct_unsorted: 20), # excluded
+        stubbed_table.merge(table_name: 'table5', stats_pct_off: 20, size_pct_unsorted: 41)  # excluded
       ]
     end
     let(:excluded_schema) do
@@ -99,8 +100,8 @@ RSpec.describe Intermix::Vacuum do
     subject do
       vacuum = Intermix::Vacuum.new(client: stubbed_client,
                                     delete_only: delete_only, full: full, sort: sort,
-                                    stats_off_threshold: stats_off_threshold, unsorted_threshold: unsorted_threshold,
-                                    vacuum_threshold: 0.99)
+                                    stats_off_threshold_pct: stats_off_threshold_pct, unsorted_threshold_pct: unsorted_threshold_pct,
+                                    vacuum_threshold_pct: 99)
       vacuum.generate_script
     end
 

--- a/spec/vacuum_spec.rb
+++ b/spec/vacuum_spec.rb
@@ -82,9 +82,9 @@ RSpec.describe Intermix::Vacuum do
     end
     let(:threshold_unmet) do
       [
-        stubbed_table.merge(table_name: 'table3', stats_pct_off: 45, size_pct_unsorted: nil),  # excluded
-        stubbed_table.merge(table_name: 'table4', stats_pct_off: 45, size_pct_unsorted: 20), # excluded
-        stubbed_table.merge(table_name: 'table5', stats_pct_off: 20, size_pct_unsorted: 41)  # excluded
+        stubbed_table.merge(table_name: 'table3', stats_pct_off: 45, size_pct_unsorted: nil), # excluded
+        stubbed_table.merge(table_name: 'table4', stats_pct_off: 45, size_pct_unsorted: 20),  # excluded
+        stubbed_table.merge(table_name: 'table5', stats_pct_off: 20, size_pct_unsorted: 41)   # excluded
       ]
     end
     let(:excluded_schema) do


### PR DESCRIPTION
1. The thresholds are actually in percents and not in decimals. `table.stats_pct_off` varies between `0.0` and `100.0`. Fix them.
2. Bump gem version to `0.0.3` with this fix.
3. Add changelog entry.